### PR TITLE
Don't skip any received data

### DIFF
--- a/filters.py
+++ b/filters.py
@@ -4,8 +4,8 @@ from scipy import signal
 
 ACC_FS = 20
 ECG_FS = 512
-PPG_FS_125 = 63 # we skip a half data point which is ambiance
-PPG_FS_512 = 256 # we skip a half data point which is ambiance
+PPG_FS_125 = 125 # don't skip any received data, ambient data has been skipped by the watch
+PPG_FS_512 = 512 # don't skip any received data, ambient data has been skipped by the watch
 
 LOW_PASS_CUTOFF = 35
 HIGH_PASS_CUTOFF = 0.5

--- a/parser.py
+++ b/parser.py
@@ -39,7 +39,7 @@ def parse_raw_ppg(x):
     """ Parse one line of raw ppg data and add it to ppg data """
     items = x.split(',')
     # convert ppg to mv
-    strs = items[2:13:2]
+    strs = items[2:13]
     nums = map(int, strs)
     nums = map(convert_ppg_to_mv, nums)
     # convert ts to ms


### PR DESCRIPTION
Ambient data has been skipped by the watch, so we don't need to do it
again. Correct the sample rate and how we collect the data.